### PR TITLE
Find the necessary row for an update by item if necessary

### DIFF
--- a/MPInspectorViewController.m
+++ b/MPInspectorViewController.m
@@ -654,8 +654,15 @@
     for (NSOutlineView *container in [self.paletteContainers allValues])
     {
         NSInteger rowIndex = [container rowForView:paletteViewController.view];
-        if (rowIndex < 0) continue;
-        
+        if (rowIndex < 0)
+        {
+            rowIndex = [container rowForItem:paletteViewController];
+        }
+        if (rowIndex < 0)
+        {
+            continue;
+        }
+
         NSIndexSet *indexSet = [[NSIndexSet alloc] initWithIndex:rowIndex];
         if (!animate)
         {


### PR DESCRIPTION
This fixes the inspector in Papers not having the correct height for the panes sometimes.
