### PR TITLE
Fixes crash on 10.9

### DIFF
--- a/MPPaletteViewController.h
+++ b/MPPaletteViewController.h
@@ -18,11 +18,8 @@ typedef NS_ENUM(NSInteger, MPPaletteViewMode)
 @class MPInspectorViewController, JKConfiguration;
 
 @interface MPPaletteViewController : PARViewController
-{    
-    __unsafe_unretained id <MPPaletteViewControllerDelegate> delegate;
-}
 
-@property (assign) id <MPPaletteViewControllerDelegate> delegate;
+@property (weak) id <MPPaletteViewControllerDelegate> delegate;
 @property (copy) NSString *identifier;
 
 @property (readonly) NSArray *displayedItems;

--- a/MPPaletteViewController.h
+++ b/MPPaletteViewController.h
@@ -23,6 +23,7 @@ typedef NS_ENUM(NSInteger, MPPaletteViewMode)
 }
 
 @property (assign) id <MPPaletteViewControllerDelegate> delegate;
+@property (copy) NSString *identifier;
 
 @property (readonly) NSArray *displayedItems;
 

--- a/MPPaletteViewController.m
+++ b/MPPaletteViewController.m
@@ -8,10 +8,15 @@
 #import "MPInspectorViewController.h"
 
 #import "MTRefreshable.h"
+
+#import <AppKit/NSUserInterfaceItemIdentification.h>
     
-@interface MPPaletteViewController ()
+@interface MPPaletteViewController () {
+    NSString *_paletteIdentifer; // For pre-10.10 compatibility with NSUserInterfaceItemIdentification
+}
 @property (getter=isVisible, assign) BOOL visible;
 @property (readonly) NSString *defaultNibName;
+
 @end
 
 
@@ -19,6 +24,8 @@
 
 @synthesize delegate = _delegate;
 @synthesize height = _height;
+
+@dynamic identifier;
 
 - (instancetype)initWithDelegate:(id <MPPaletteViewControllerDelegate>)aDelegate identifier:(NSString *)identifier
 {
@@ -53,6 +60,21 @@
 	return (r.location != NSNotFound ? [className substringToIndex:r.location] : className);
 }
 
+- (NSString *)identifier {
+    if ([self conformsToProtocol:@protocol(NSUserInterfaceItemIdentification)]) {
+        return [super identifier];
+    } else {
+        return _paletteIdentifer;
+    }
+}
+
+- (void)setIdentifier:(NSString *)identifier {
+    if ([self conformsToProtocol:@protocol(NSUserInterfaceItemIdentification)]) {
+        [super setIdentifier:identifier];
+    } else {
+        _paletteIdentifer = [identifier copy];
+    }
+}
 
 #pragma mark -
 #pragma mark Refresh


### PR DESCRIPTION
In 10.10 and newer, something in the class hierarchy of `MPPaletteViewController` implements `NSUserInterfaceItemIdentification`, which adds an `identifier` string property to the class. 10.9 and earlier doesn't do that, so instead we crash when trying to set the identifier.

This adds the identifier property again, and uses the system implementation of the method if it exists.

Fixes https://github.com/mekentosj/papers-mac/issues/5288